### PR TITLE
Update LAB_AK_01_Implementing_identity_services_and_Group_Policy.md

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Implementing_identity_services_and_Group_Policy.md
+++ b/Instructions/Labs/LAB_AK_01_Implementing_identity_services_and_Group_Policy.md
@@ -65,7 +65,7 @@ lab:
 1. Place the cursor between the braces (**{ }**), and then paste the content of the copied script line from the clipboard. The complete command should have the following format:
 	
    ```powershell
-   Invoke-Command –ComputerName SEA-SVR1 {Install-ADDSDomainController -NoGlobalCatalog:\$false -CreateDnsDelegation:\$false -Credential (Get-Credential) -CriticalReplicationOnly:\$false -DatabasePath "C:\Windows\NTDS" -DomainName "Contoso.com" -InstallDns:\$true -LogPath "C:\Windows\NTDS" -NoRebootOnCompletion:\$false -SiteName "Default-First-Site-Name" -SysvolPath "C:\Windows\SYSVOL" -Force:\$true}
+   Invoke-Command –ComputerName SEA-SVR1 {Install-ADDSDomainController -NoGlobalCatalog:$false -CreateDnsDelegation:$false -Credential (Get-Credential) -CriticalReplicationOnly:$false -DatabasePath "C:\Windows\NTDS" -DomainName "Contoso.com" -InstallDns:$true -LogPath "C:\Windows\NTDS" -NoRebootOnCompletion:$false -SiteName "Default-First-Site-Name" -SysvolPath "C:\Windows\SYSVOL" -Force:$true}
    ```
 1. To invoke the command, press Enter.
 1. In the **Windows PowerShell Credential Request** dialog box, enter **CONTOSO\\Administrator** in the **User name** box, enter **Pa55w.rd** in the **Password** box, and then select **OK**.


### PR DESCRIPTION
fixed PowerShell command line syntax error caused by backslashes in front of $true/$false"

# Module: 00
## Lab/Demo: 00

Fixes # . Removed extra backslahes causing a syntax error in PowerShell

Changes proposed in this pull request:

-
-
-