### PR TITLE
Updated PowerShell commands referencing DockerMsftProvider with Docke…

### DIFF
--- a/Instructions/Labs/LAB_05_Implementing_and_configuring_virtualization_in_Windows_Server.md
+++ b/Instructions/Labs/LAB_05_Implementing_and_configuring_virtualization_in_Windows_Server.md
@@ -157,12 +157,12 @@ The main tasks for this exercise are as follows:
 1. In the **Windows PowerShell** console, run the following command to install the Docker Microsoft PackageManagement provider on **SEA-SVR1**:
 
    ```powershell
-   Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
+   Install-Module -Name DockerProvider -Repository PSGallery -Force
    ```
 1. In the **Windows PowerShell** console, run the following command to install the Docker runtime on **SEA-SVR1**:
 
    ```powershell
-   Install-Package -Name docker -ProviderName DockerMsftProvider
+   Install-Package -Name docker -ProviderName DockerProvider
    ```
 1. After the installation completes, run the following commands to restart **SEA-SVR1**:
 
@@ -176,7 +176,7 @@ The main tasks for this exercise are as follows:
 1. In the **Windows PowerShell** console, run the following command to verify the installed version of Docker:
 
    ```powershell
-   Get-Package -Name Docker -ProviderName DockerMsftProvider
+   Get-Package -Name Docker -ProviderName DockerProvider
    ```
 1. Run the following command to identify Docker images currently present on **SEA-SVR1**: 
 


### PR DESCRIPTION
# Learning Path: 05
## Exercise: 02


Fixes 

PS commands referencing DockerMsftProvider fail due to Provider being offline (https://github.com/OneGet/MicrosoftDockerProvider). Changing the reference to DockerProvider allows the commands to succeed and complete the lab as expected.


Changes proposed in this pull request:


Exercise 2, Task 1, step 6

Install-Module DockerProvider

 
Exercise 2, Task 1, step 8

Install-Package Docker -ProviderName DockerProvider

 
Exercise 2, Task 2, step 4

Get-Package -Name Docker -ProviderName DockerProvider


![image](https://github.com/MicrosoftLearning/AZ-800-Administering-Windows-Server-Hybrid-Core-Infrastructure/assets/94069201/9aa62648-86a5-4a91-8ae8-714b9495f6de)
