### PR TITLE
Lab 6 Ex 5 Task 2: Public IP creation fails; Create public IP resource before editing VM IP

### DIFF
--- a/Instructions/Labs/LAB_AK_06_Deploying_and_configuring_Windows_Server_on_Azure_VMs.md
+++ b/Instructions/Labs/LAB_AK_06_Deploying_and_configuring_Windows_Server_on_Azure_VMs.md
@@ -217,21 +217,28 @@ In this task, you will use the Azure portal to create resource groups and create
 
 #### Task 2: Configure Inbound HTTP access to an Azure VM
 
+1. In the Azure portal, on the toolbar, in the **Search resources, services, and docs** text box, search for and select **Public IP address**.
+1. On the **Public IP address** page, select **+ Create**.
+1. On the **Basics** tab of the **Create public IP address** page, specify the following settings (leave others with their default values):
+
+   |Setting|Value|
+   |---|---|
+   |Subscription|the name of the Azure subscription you are using in this lab|
+   |Resource group|**AZ800-L0601-RG**|
+   |Name|**az800l06-vm0-pip1**|
+   |Region|the name of the Azure region into which you provisioned the Azure VM **az800l06-vm0**|
+   |SKU|**Standard**|
+
+1. On the **Create public IP address** page, on the **Basics** tab, select **Review + create**, and then select **Create**.
+1. Verify that the deployment completed successfully.
 1. In the Azure portal, browse back to the **AZ800-L0601-RG** page, and then in the list of resources, select the entry representing the Azure VM **az800l06-vm0**.
 1. On the **az800l06-vm0** page, select **Networking**.
 1. On the **az800l06-vm0 \| Networking** page, select the link designating the network interface attached to **az800l06-vm0**.
 1. On the page displaying the network interface properties, in the vertical menu on the left side, in the **Settings** section, select **Network security group**. 
 1. On the **Network security group** page, in the drop-down list, select **az800l06-vm0-nsg1**, and then select **Save**.
 1. Back on the page displaying the properties of the network interface, select **IP configurations**, and then select the **ipconfig1** entry.
-1. On the **ipconfig1** page, in the **Public IP address** section, select **Associate**, and then, below the **Public IP address** drop-down list, select **Create new**.
-1. In the **Add a public IP address** window, specify the following settings, and then select **OK**:
-
-   |Setting|Value|
-   |---|---|
-   |Name|**az800l06-vm0-pip1**|
-   |SKU|**Standard**|
-
-1. Back on the **ipconfig1** page, select **Save**.
+1. On the **ipconfig1** page, in the **Public IP address** section, select **Associate**, and then select **az800l06-vm0-pip1** from the **Public IP address** drop-down list.
+1. On the **ipconfig1** page, select **Save**.
 1. Browse back to the page displaying the network interface properties and select **Overview**. Note the value of the public IP address assigned to the interface.
 1. Open another browser tab, browse to that IP address, and verify that a webpage opens, displaying **Hello World from az800l06-vm0**.
 1. From the lab computer, start the Remote Desktop app, and try connecting to the same IP address. Verify that the connection fails.


### PR DESCRIPTION
- Lab answer key: Deploying and configuring Windows Server on Azure VMs
- Exercise 5: Configuring Windows Server security in Azure VMs
- Task 2: Configure Inbound HTTP access to an Azure VM

When editing the `az800l06-vm0` IP configuration in the above task, the public IP resource currently cannot be deployed from the **Edit IP Configuration** blade as specified in the instructions. The resource fails to deploy due to the Azure portal default `domainNameLabel` configuration now specified for that resource. The DNS record is already reserved. Please see the template and deployment excerpts below for reference.

Creation of the public IP resource via the **Create a public IP address** page does not enforce this default currently. To resolve the issue identified above, create the public IP resource in this way prior to the existing Task 2 steps.

Template excerpt:
```json
{
    "type": "Microsoft.Network/publicIpAddresses",
    "apiVersion": "2022-05-01",
    "name": "az800l06-vm0-pip1",
    "location": "eastus",
    "sku": {
        "name": "Standard",
        "tier": "Regional"
    },
    "properties": {
        "publicIPAllocationMethod": "Static",
        "idleTimeoutInMinutes": 4,
        "publicIpAddressVersion": "IPv4",
        "dnsSettings": {
            "domainNameLabel": "az800l06-vm0-pip1"
        }
    },
    "id": "/subscriptions/<uuid>/resourceGroups/AZ800-L0601-RG/providers/Microsoft.Network/publicIpAddresses/az800l06-vm0-pip1"
}
```

Deployment exerpt:
```json
    "error": {
      "code": "DeploymentFailed",
      "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
      "details": [
        {
          "code": "DnsRecordIsReserved",
          "message": "DNS record az800l06-vm0-pip1.eastus.cloudapp.azure.com is already reserved by another resource."
        }
      ]
    }
```

Changes proposed in this pull request:

- Create the public IP resource before continuing with the existing Task 2
- Select the already-created public IP at Task 2 step 7 (existing numbering)