### PR TITLE
Update L04-rg_template.json Basic SKU Public IPs are deprecated

### DIFF
--- a/Allfiles/Labfiles/Lab04/L04-rg_template.json
+++ b/Allfiles/Labfiles/Lab04/L04-rg_template.json
@@ -74,11 +74,11 @@
       "apiVersion": "[variables('networkAPIVersion')]",
       "location": "[resourceGroup().location]",
       "sku": {
-       "name": "Basic"
+       "name": "Standard"
       },
       "properties": {
         "publicIPAddressVersion": "IPv4",
-        "publicIPAllocationMethod": "Dynamic",
+        "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4
       }
     },


### PR DESCRIPTION


# Module/Lab: 04

Changes proposed in this pull request:
It's no longer possible to create Basic SKU public IP addresses after March 31, 2025 due to the SKU being deprecated.


