### PR TITLE
Update VM size and SKU in JSON template

### DIFF
--- a/Allfiles/Labfiles/Lab04/Deploy-WACAzVM.ps1
+++ b/Allfiles/Labfiles/Lab04/Deploy-WACAzVM.ps1
@@ -171,12 +171,12 @@ param (
     [Parameter(ParameterSetName='CreateVMGenerateCert', Mandatory=$false)]
     [Parameter(ParameterSetName='CreateVMSpecifyCert', Mandatory=$false)]
     [String]
-    $Size = "Standard_DS1_v2",
+    $Size = "Standard_D2s_v7",
 
     [Parameter(ParameterSetName='CreateVMGenerateCert', Mandatory=$false)]
     [Parameter(ParameterSetName='CreateVMSpecifyCert', Mandatory=$false)]
     [String]
-    $Image = "Win2019Datacenter",
+    $Image = "MicrosoftWindowsServer:WindowsServer:2022-Datacenter-g2:latest",
 
     [Parameter(ParameterSetName='CreateVMGenerateCert', Mandatory=$false)]
     [Parameter(ParameterSetName='CreateVMSpecifyCert', Mandatory=$false)]

--- a/Allfiles/Labfiles/Lab04/L04-rg_template.json
+++ b/Allfiles/Labfiles/Lab04/L04-rg_template.json
@@ -30,7 +30,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_D2s_v3",
+      "defaultValue": "Standard_D2s_v7",
       "metadata": {
         "description": "VM size"
       }
@@ -60,7 +60,7 @@
     "windowsImage": {
       "publisher": "MicrosoftWindowsServer",
       "offer": "WindowsServer",
-      "sku": "2022-Datacenter",
+      "sku": "2022-Datacenter-g2",
       "version": "latest"
     },
     "computeAPIVersion": "2019-07-01",


### PR DESCRIPTION
This pull request updates the default configuration for virtual machines in the `L04-rg_template.json` ARM template. The changes primarily focus on updating the VM size and the Windows Server image SKU to use newer versions.

**Template configuration updates:**

* Changed the default VM size from `Standard_D2s_v3` to `Standard_D2s_v7` for improved performance and access to newer hardware.
* Updated the Windows Server image SKU from `2022-Datacenter` to `2022-Datacenter-g2` to use the latest generation 2 image.
